### PR TITLE
Features/inline partials

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,4 @@
 {
-  "projects": [ "src", "test" ]
+  "projects": [ "src", "test" ],
+  "sdk": { "version": "1.0.0-preview2-1-003177" }
 }

--- a/src/Mustache/Context.cs
+++ b/src/Mustache/Context.cs
@@ -10,7 +10,7 @@
         /// </summary>
         /// <param name="tagName">The name of the tag that created the context.</param>
         /// <param name="parameters">The context parameters.</param>
-        internal Context(string tagName, ContextParameter[] parameters)
+        internal Context(string tagName, params ContextParameter[] parameters)
         {
             TagName = tagName;
             Parameters = parameters;

--- a/src/Mustache/FormatCompiler.cs
+++ b/src/Mustache/FormatCompiler.cs
@@ -291,6 +291,7 @@ namespace Mustache
                 {
                     formatIndex = match.Index + match.Length;
 
+                    // add the template definition to the lookup
                     partials.Add(match.Groups["name"].Value, match.Groups["definition"].Value);
                 }
                 // if we come across a call for a partial template
@@ -302,7 +303,7 @@ namespace Mustache
                     if (!leading.Equals(string.Empty))
                         generator.AddGenerator(new StaticGenerator(leading, RemoveNewLines));
 
-                    var partialTag = new PartialCallTagDefinition(hasContent: false);
+                    var partialTag = new PartialCallTagDefinition();
 
                     // retrieve the arguments from the regex
                     ArgumentCollection arguments = getArguments(partialTag, match, context);

--- a/src/Mustache/FormatCompiler.cs
+++ b/src/Mustache/FormatCompiler.cs
@@ -14,6 +14,7 @@ namespace Mustache
     {
         private readonly Dictionary<string, TagDefinition> _tagLookup;
         private readonly Dictionary<string, Regex> _regexLookup;
+        private readonly Dictionary<string, string> _partialLookup;
         private readonly MasterTagDefinition _masterDefinition;
 
         /// <summary>
@@ -23,6 +24,7 @@ namespace Mustache
         {
             _tagLookup = new Dictionary<string, TagDefinition>();
             _regexLookup = new Dictionary<string, Regex>();
+            _partialLookup = new Dictionary<string, string>();
             _masterDefinition = new MasterTagDefinition();
 
             IfTagDefinition ifDefinition = new IfTagDefinition();
@@ -84,6 +86,11 @@ namespace Mustache
             _tagLookup.Add(definition.Name, definition);
         }
 
+        public void RegisterPartial(string name, string template)
+        {
+            _partialLookup.Add(name, template);
+        }
+
         /// <summary>
         /// Builds a text generator based on the given format.
         /// </summary>
@@ -96,10 +103,12 @@ namespace Mustache
                 throw new ArgumentNullException("format");
             }
             CompoundGenerator generator = new CompoundGenerator(_masterDefinition, new ArgumentCollection());
+            Dictionary<string, string> partials = new Dictionary<string, string>(_partialLookup);
             List<Context> context = new List<Context>() { new Context(_masterDefinition.Name, new ContextParameter[0]) };
-            int formatIndex = buildCompoundGenerator(_masterDefinition, context, generator, format, 0);
+            int formatIndex = buildCompoundGenerator(_masterDefinition, partials, context, generator, format, 0);
             string trailing = format.Substring(formatIndex);
-            generator.AddGenerator(new StaticGenerator(trailing, RemoveNewLines));
+            if (!trailing.Equals(string.Empty))
+                generator.AddGenerator(new StaticGenerator(trailing, RemoveNewLines));
             return new Generator(generator);
         }
 
@@ -117,6 +126,7 @@ namespace Mustache
                 List<string> matches = new List<string>();
                 matches.Add(getKeyRegex());
                 matches.Add(getCommentTagRegex());
+                matches.Add(getPartialRegex());
                 foreach (string closingTag in definition.ClosingTags)
                 {
                     matches.Add(getClosingTagRegex(closingTag));
@@ -166,6 +176,18 @@ namespace Mustache
             return @"((?<key>" + RegexHelper.CompoundKey + @")(,(?<alignment>(\+|-)?[\d]+))?(:(?<format>.*?))?)";
         }
 
+        private static string getPartialRegex()
+        {
+            StringBuilder regexBuilder = new StringBuilder();
+            regexBuilder.Append(@"(?<call>");
+            regexBuilder.Append(@">\s+?(?<name>(?<argument>");
+            regexBuilder.Append(RegexHelper.Key);
+            regexBuilder.Append(@"))\s+?(?<context>(?<argument>");
+            regexBuilder.Append(RegexHelper.CompoundKey);
+            regexBuilder.Append(@"))?\s*?)");
+            return regexBuilder.ToString();
+        }
+
         private static string getTagRegex(TagDefinition definition)
         {
             StringBuilder regexBuilder = new StringBuilder();
@@ -194,6 +216,7 @@ namespace Mustache
 
         private int buildCompoundGenerator(
             TagDefinition tagDefinition,
+            Dictionary<string, string> partials,
             List<Context> context,
             CompoundGenerator generator,
             string format, int formatIndex)
@@ -216,7 +239,8 @@ namespace Mustache
 
                 if (match.Groups["key"].Success)
                 {
-                    generator.AddGenerator(new StaticGenerator(leading, RemoveNewLines));
+                    if (!leading.Equals(string.Empty))
+                        generator.AddGenerator(new StaticGenerator(leading, RemoveNewLines));
                     formatIndex = match.Index + match.Length;
                     bool isExtension = match.Groups["extension"].Success;
                     string key = match.Groups["key"].Value;
@@ -249,6 +273,56 @@ namespace Mustache
                     KeyGenerator keyGenerator = new KeyGenerator(key, alignment, formatting, isExtension);
                     generator.AddGenerator(keyGenerator);
                 }
+                // if we come across a call for a partial template
+                else if (match.Groups["call"].Success)
+                {
+                    formatIndex = match.Index + match.Length;
+
+                    // include the substring since the last match
+                    if (!leading.Equals(string.Empty))
+                        generator.AddGenerator(new StaticGenerator(leading, RemoveNewLines));
+
+                    var partialTag = new PartialCallTagDefinition(hasContent: false);
+
+                    // retrieve the arguments from the regex
+                    ArgumentCollection arguments = getArguments(partialTag, match, context);
+
+                    string name = match.Groups["name"].Value;
+
+                    string partialTemplate;
+                    if (partials.TryGetValue(name, out partialTemplate))
+                    {
+                        bool hasContext = match.Groups["context"].Success;
+                        if (hasContext)
+                        {
+                            // if a special context is to be provided, do it
+                            var contextString = match.Groups["context"].Value;
+                            var param = new ContextParameter("context", contextString);
+                            context.Add(new Context(partialTag.Name, param));
+                        }
+
+                        // include a fully compiled copy of the template
+                        CompoundGenerator partialGenerator = new CompoundGenerator(partialTag, arguments);
+                        int trailingIndex = buildCompoundGenerator(partialTag, partials, context, partialGenerator, partialTemplate, 0);
+                        generator.AddGenerator(partialGenerator);
+
+                        // and the part of the template after the last match
+                        string trailing = partialTemplate.Substring(trailingIndex);
+                        if (!trailing.Equals(string.Empty))
+                            generator.AddGenerator(new StaticGenerator(trailing, RemoveNewLines));
+
+                        if (hasContext)
+                        {
+                            // undo the context change
+                            context.RemoveAt(context.Count - 1);
+                        }
+                    }
+                    else
+                    {
+                        string message = String.Format(Resources.PartialNotDefined, name);
+                        throw new FormatException(message);
+                    }
+                }
                 else if (match.Groups["open"].Success)
                 {
                     formatIndex = match.Index + match.Length;
@@ -260,7 +334,8 @@ namespace Mustache
                         throw new FormatException(message);
                     }
 
-                    generator.AddGenerator(new StaticGenerator(leading, RemoveNewLines));
+                    if (!leading.Equals(string.Empty))
+                        generator.AddGenerator(new StaticGenerator(leading, RemoveNewLines));
                     ArgumentCollection arguments = getArguments(nextDefinition, match, context);
 
                     if (nextDefinition.HasContent)
@@ -273,7 +348,7 @@ namespace Mustache
                             ContextParameter[] parameters = contextParameters.Select(p => new ContextParameter(p.Name, arguments.GetKey(p))).ToArray();
                             context.Add(new Context(nextDefinition.Name, parameters));
                         }
-                        formatIndex = buildCompoundGenerator(nextDefinition, context, compoundGenerator, format, formatIndex);
+                        formatIndex = buildCompoundGenerator(nextDefinition, partials, context, compoundGenerator, format, formatIndex);
                         generator.AddGenerator(nextDefinition, compoundGenerator);
                         if (hasContext)
                         {
@@ -288,7 +363,8 @@ namespace Mustache
                 }
                 else if (match.Groups["close"].Success)
                 {
-                    generator.AddGenerator(new StaticGenerator(leading, RemoveNewLines));
+                    if (!leading.Equals(string.Empty))
+                        generator.AddGenerator(new StaticGenerator(leading, RemoveNewLines));
                     string tagName = match.Groups["name"].Value;
                     TagDefinition nextDefinition = _tagLookup[tagName];
                     formatIndex = match.Index;
@@ -300,7 +376,8 @@ namespace Mustache
                 }
                 else if (match.Groups["comment"].Success)
                 {
-                    generator.AddGenerator(new StaticGenerator(leading, RemoveNewLines));
+                    if (!leading.Equals(string.Empty))
+                        generator.AddGenerator(new StaticGenerator(leading, RemoveNewLines));
                     formatIndex = match.Index + match.Length;
                 }
                 else if (match.Groups["unknown"].Success)

--- a/src/Mustache/PartialCallTagDefinition.cs
+++ b/src/Mustache/PartialCallTagDefinition.cs
@@ -19,19 +19,14 @@ namespace Mustache
             new TagParameter(ContextParameter) { IsRequired = false }
         };
 
-        private bool _hasContent;
-
-        public PartialCallTagDefinition(bool hasContent)
-            : base(PartialCallTag, true)
-        {
-            this._hasContent = hasContent;
-        }
+        public PartialCallTagDefinition()
+            : base(PartialCallTag, true) { }
 
         protected override IEnumerable<TagParameter> GetParameters() => InnerTags;
 
         public override IEnumerable<TagParameter> GetChildContextParameters() => InnerContextTags;
 
-        protected override bool GetHasContent() => _hasContent;
+        protected override bool GetHasContent() => false;
 
         public override IEnumerable<NestedContext> GetChildContext(
             TextWriter writer,
@@ -40,9 +35,16 @@ namespace Mustache
             Scope contextScope)
         {
             object contextSource = arguments[ContextParameter];
+
+            Scope scope;
+            if (contextSource == null)
+                scope = keyScope.CreateChildScope();
+            else
+                scope = keyScope.CreateChildScope(contextSource);
+
             NestedContext context = new NestedContext()
             {
-                KeyScope = keyScope.CreateChildScope(contextSource),
+                KeyScope = scope,
                 Writer = writer,
                 ContextScope = contextScope.CreateChildScope()
             };

--- a/src/Mustache/PartialCallTagDefinition.cs
+++ b/src/Mustache/PartialCallTagDefinition.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Mustache
+{
+    public class PartialCallTagDefinition : TagDefinition
+    {
+        private const string PartialCallTag = ">";
+        private const string NameParameter = "name";
+        private const string ContextParameter = "context";
+        private static readonly TagParameter[] InnerTags =
+        {
+            new TagParameter(NameParameter) { IsRequired = true },
+            new TagParameter(ContextParameter) { IsRequired = false }
+        };
+        private static readonly TagParameter[] InnerContextTags =
+        {
+            new TagParameter(ContextParameter) { IsRequired = false }
+        };
+
+        private bool _hasContent;
+
+        public PartialCallTagDefinition(bool hasContent)
+            : base(PartialCallTag, true)
+        {
+            this._hasContent = hasContent;
+        }
+
+        protected override IEnumerable<TagParameter> GetParameters() => InnerTags;
+
+        public override IEnumerable<TagParameter> GetChildContextParameters() => InnerContextTags;
+
+        protected override bool GetHasContent() => _hasContent;
+
+        public override IEnumerable<NestedContext> GetChildContext(
+            TextWriter writer,
+            Scope keyScope,
+            Dictionary<string, object> arguments,
+            Scope contextScope)
+        {
+            object contextSource = arguments[ContextParameter];
+            NestedContext context = new NestedContext()
+            {
+                KeyScope = keyScope.CreateChildScope(contextSource),
+                Writer = writer,
+                ContextScope = contextScope.CreateChildScope()
+            };
+            yield return context;
+        }
+    }
+}

--- a/src/Mustache/Properties/Resources.Designer.cs
+++ b/src/Mustache/Properties/Resources.Designer.cs
@@ -105,6 +105,15 @@ namespace Mustache.Properties {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to A partial template named {0} could not be found..
+        /// </summary>
+        public static string PartialNotDefined {
+            get {
+                return ResourceManager.GetString("PartialNotDefined", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Encountered an unknown tag: {0}. It was either not registered or exists in a different context..
         /// </summary>
         public static string UnknownTag {

--- a/src/Mustache/Properties/Resources.resx
+++ b/src/Mustache/Properties/Resources.resx
@@ -132,6 +132,9 @@
   <data name="MissingClosingTag" xml:space="preserve">
     <value>Expected a matching {0} tag but none was found.</value>
   </data>
+  <data name="PartialNotDefined" xml:space="preserve">
+    <value>A partial template named {0} could not be found.</value>
+  </data>
   <data name="UnknownTag" xml:space="preserve">
     <value>Encountered an unknown tag: {0}. It was either not registered or exists in a different context.</value>
   </data>

--- a/src/Mustache/project.json
+++ b/src/Mustache/project.json
@@ -13,7 +13,7 @@
     },
     "tags": [ "mustache", "handlebars.js", "text", "generation", "building", "template" ]
   },
-  "version": "1.0.1-*",
+  "version": "1.0.2-*",
 
   "buildOptions": {
     "embed": {

--- a/test/Mustache.Benchmarks/project.json
+++ b/test/Mustache.Benchmarks/project.json
@@ -10,7 +10,7 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "MustacheSharp": "1.0.1-*"
+    "Mustache": "1.0.1-*"
   },
 
   "frameworks": {

--- a/test/Mustache.Benchmarks/project.json
+++ b/test/Mustache.Benchmarks/project.json
@@ -10,7 +10,7 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "Mustache": "1.0.1-*"
+    "Mustache": "1.0.2-*"
   },
 
   "frameworks": {

--- a/test/Mustache.Test/FormatCompilerTester.cs
+++ b/test/Mustache.Test/FormatCompilerTester.cs
@@ -1629,9 +1629,9 @@ Odd
         public void TestCompile_NoPartial_ShouldThrow()
         {
             FormatCompiler compiler = new FormatCompiler();
-            string format = $"{{> {TestPartial.Key} }}";
+            string format = "{{> " + TestPartial.Key + " }}";
 
-            Assert.Throws<KeyNotFoundException>(() =>
+            Assert.Throws<FormatException>(() =>
             {
                 Generator generator = compiler.Compile(format);
 
@@ -1648,43 +1648,29 @@ Odd
         public void TestCompile_BasicPartials()
         {
             FormatCompiler compiler = new FormatCompiler();
-            compiler.RegisterPartial(TestPartial);
-            string format = $"{{> {TestPartial.Key} }}";
+            compiler.RegisterPartial(TestPartial.Key, TestPartial.Value);
+            string format = "Maybe {{> " + TestPartial.Key + " }} after all";
             Generator generator = compiler.Compile(format);
             const string name = "I am myself";
             string result = generator.Render(new { Name = name });
-            Assert.Equal(name, result);
+            Assert.Equal(name, $"Maybe ${result} after all");
         }
 
 
         /// <summary>
         /// Dynamic partials are not supported
         /// http://handlebarsjs.com/partials.html#dynamic-partials
-        /// You can pass custom contexts to the partial template calls.
+        /// Partial parameters aren't either
+        /// http://handlebarsjs.com/partials.html#partial-parameters
+        /// But you can pass custom contexts to the partial template calls.
         /// http://handlebarsjs.com/partials.html#partial-context
         /// </summary>
         [Fact]
         public void TestCompile_PartialContexts()
         {
             FormatCompiler compiler = new FormatCompiler();
-            compiler.RegisterPartial(TestPartial);
-            string format = $"{{> {TestPartial.Key} Person }}";
-            Generator generator = compiler.Compile(format);
-            const string name = "I am myself";
-            string result = generator.Render(new { Person = new { Name = name } });
-            Assert.Equal(name, result);
-        }
-
-        /// <summary>
-        /// http://handlebarsjs.com/partials.html#partial-parameters
-        /// You can pass custom parameters to partials.
-        /// </summary>
-        [Fact]
-        public void TestCompile_PartialParameters()
-        {
-            FormatCompiler compiler = new FormatCompiler();
-            compiler.RegisterPartial(TestPartial);
-            string format = $"{{> {TestPartial.Key} Name=Person.Name }}";
+            compiler.RegisterPartial(TestPartial.Key, TestPartial.Value);
+            string format = "{{> " + TestPartial.Key + " Person }}";
             Generator generator = compiler.Compile(format);
             const string name = "I am myself";
             string result = generator.Render(new { Person = new { Name = name } });
@@ -1703,7 +1689,7 @@ Odd
             // Template passing (using "@partial-block") is not supported
             FormatCompiler compiler = new FormatCompiler();
             const string failover = "Failover content";
-            string format = $@"{{> {TestPartial.Key} }}{failover}{{/{TestPartial.Key}}}";
+            string format = "{{> " + TestPartial.Key + " }}" + failover + "{{/" + TestPartial.Key + "}}";
             Generator generator = compiler.Compile(format);
             string result = generator.Render(null);
             Assert.Equal(failover, result);

--- a/test/Mustache.Test/FormatCompilerTester.cs
+++ b/test/Mustache.Test/FormatCompilerTester.cs
@@ -1614,6 +1614,12 @@ Odd
         #endregion
 
         #region Partials
+        /// Dynamic partials are not supported
+        /// http://handlebarsjs.com/partials.html#dynamic-partials
+        /// Partial parameters aren't either
+        /// http://handlebarsjs.com/partials.html#partial-parameters
+        /// No luck with partial blocks and failovers
+        /// http://handlebarsjs.com/partials.html#partial-block
 
         /// <summary>
         /// Stores a basic definition of a partial to be used in unit tests.
@@ -1658,11 +1664,7 @@ Odd
 
 
         /// <summary>
-        /// Dynamic partials are not supported
-        /// http://handlebarsjs.com/partials.html#dynamic-partials
-        /// Partial parameters aren't either
-        /// http://handlebarsjs.com/partials.html#partial-parameters
-        /// But you can pass custom contexts to the partial template calls.
+        /// You can pass custom contexts to the partial template calls.
         /// http://handlebarsjs.com/partials.html#partial-context
         /// </summary>
         [Fact]
@@ -1678,24 +1680,6 @@ Odd
         }
 
         /// <summary>
-        /// http://handlebarsjs.com/partials.html#partial-block
-        /// To not throw errors for partials that may not be defined,
-        /// you can pass in a block of failover content to be displayed
-        /// should the partial not be found.
-        /// </summary>
-        [Fact]
-        public void TestCompile_PartialBlocks_WithFailover()
-        {
-            // Template passing (using "@partial-block") is not supported
-            FormatCompiler compiler = new FormatCompiler();
-            const string failover = "Failover content";
-            string format = "{{> " + TestPartial.Key + " }}" + failover + "{{/" + TestPartial.Key + "}}";
-            Generator generator = compiler.Compile(format);
-            string result = generator.Render(null);
-            Assert.Equal(failover, result);
-        }
-
-        /// <summary>
         /// http://handlebarsjs.com/partials.html#inline-partials
         /// Inline partials will be available to the current block and all children.
         /// However, having them available in the execution of other partials is not supported.
@@ -1704,19 +1688,19 @@ Odd
         public void TestCompile_InlinePartials()
         {
             FormatCompiler compiler = new FormatCompiler();
-            string format = string.Format(@"{{#*inline ""{0}""}}{1}{{#newline}}{{/inline}}
-{#each Names}}
-  {{> {0}}}
-{{/each}}", TestPartial.Key, TestPartial.Value);
+            string format = "{{#*inline \"" + TestPartial.Key + "\"}}" +
+                TestPartial.Value + "{{#newline}}{{/inline}}" +
+                "{{#each Names}}{{> " + TestPartial.Key + "}}{{/each}}";
             Generator generator = compiler.Compile(format);
+
             string[] names = new string[]
             {
                 "I am myself",
                 "You are not different from me",
                 "And you never were."
             };
-            string result = generator.Render(new { Names = names });
-            Assert.Equal(string.Join("\n", names), result);
+            string result = generator.Render(new { Names = names.Select(s => new { Name = s }) });
+            Assert.Equal(string.Join(string.Empty, names.Select(s => s + "\r\n")), result);
         }
 
         #endregion

--- a/test/Mustache.Test/FormatCompilerTester.cs
+++ b/test/Mustache.Test/FormatCompilerTester.cs
@@ -1653,7 +1653,7 @@ Odd
             Generator generator = compiler.Compile(format);
             const string name = "I am myself";
             string result = generator.Render(new { Name = name });
-            Assert.Equal(name, $"Maybe ${result} after all");
+            Assert.Equal($"Maybe {name} after all", result);
         }
 
 

--- a/test/Mustache.Test/FormatCompilerTester.cs
+++ b/test/Mustache.Test/FormatCompilerTester.cs
@@ -1618,8 +1618,8 @@ Odd
         /// <summary>
         /// Stores a basic definition of a partial to be used in unit tests.
         /// </summary>
-        private readonly PartialDefinition TestPartial =
-            new PartialDefinition("myPartial", "{{Name}}");
+        private readonly KeyValuePair<string, string> TestPartial =
+            new KeyValuePair<string, string>("myPartial", "{{Name}}");
 
         /// <summary>
         /// The normal behavior [when rendering] a partial that is not found
@@ -1629,9 +1629,9 @@ Odd
         public void TestCompile_NoPartial_ShouldThrow()
         {
             FormatCompiler compiler = new FormatCompiler();
-            const string format = $"{{> {TestPartial.Name} }}";
+            string format = $"{{> {TestPartial.Key} }}";
 
-            Assert.Throws<PartialNotFoundException>(() =>
+            Assert.Throws<KeyNotFoundException>(() =>
             {
                 Generator generator = compiler.Compile(format);
 
@@ -1649,7 +1649,7 @@ Odd
         {
             FormatCompiler compiler = new FormatCompiler();
             compiler.RegisterPartial(TestPartial);
-            const string format = $"{{> {TestPartial.Name} }}";
+            string format = $"{{> {TestPartial.Key} }}";
             Generator generator = compiler.Compile(format);
             const string name = "I am myself";
             string result = generator.Render(new { Name = name });
@@ -1668,7 +1668,7 @@ Odd
         {
             FormatCompiler compiler = new FormatCompiler();
             compiler.RegisterPartial(TestPartial);
-            const string format = $"{{> {TestPartial.Name} Person }}";
+            string format = $"{{> {TestPartial.Key} Person }}";
             Generator generator = compiler.Compile(format);
             const string name = "I am myself";
             string result = generator.Render(new { Person = new { Name = name } });
@@ -1684,7 +1684,7 @@ Odd
         {
             FormatCompiler compiler = new FormatCompiler();
             compiler.RegisterPartial(TestPartial);
-            const string format = $"{{> {TestPartial.Name} Name=Person.Name }}";
+            string format = $"{{> {TestPartial.Key} Name=Person.Name }}";
             Generator generator = compiler.Compile(format);
             const string name = "I am myself";
             string result = generator.Render(new { Person = new { Name = name } });
@@ -1703,7 +1703,7 @@ Odd
             // Template passing (using "@partial-block") is not supported
             FormatCompiler compiler = new FormatCompiler();
             const string failover = "Failover content";
-            const string format = $@"{{> {TestPartial.Name} }}{failover}{{/{TestPartial.Name}}}";
+            string format = $@"{{> {TestPartial.Key} }}{failover}{{/{TestPartial.Key}}}";
             Generator generator = compiler.Compile(format);
             string result = generator.Render(null);
             Assert.Equal(failover, result);
@@ -1718,10 +1718,10 @@ Odd
         public void TestCompile_InlinePartials()
         {
             FormatCompiler compiler = new FormatCompiler();
-            const string format = string.Format(@"{{#*inline ""{0}""}}{1}{{#newline}}{{/inline}}
+            string format = string.Format(@"{{#*inline ""{0}""}}{1}{{#newline}}{{/inline}}
 {#each Names}}
   {{> {0}}}
-{{/each}}", TestPartial.Name, TestPartial.Definition);
+{{/each}}", TestPartial.Key, TestPartial.Value);
             Generator generator = compiler.Compile(format);
             string[] names = new string[]
             {

--- a/test/Mustache.Test/project.json
+++ b/test/Mustache.Test/project.json
@@ -9,7 +9,7 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "Mustache": "1.0.1-*",
+    "Mustache": "1.0.2-*",
     "xunit": "2.2.0-beta2-build3300"
   },
 


### PR DESCRIPTION
Updated to use .NET Core 1.0.1 and implemented basic partial templates, including inline definitions and context passing.